### PR TITLE
Impl backslash escape for new line in preprocessor token

### DIFF
--- a/src/preprocess/preprocess.rs
+++ b/src/preprocess/preprocess.rs
@@ -95,7 +95,7 @@ impl<'b> Preprocessor<'b> {
                                 continue;
                             }
                             ifdefkind @ ("ifdef" | "ifndef") => {
-                                main_chars.get_debug_info_and_skip_white_space_without_new_line();
+                                main_chars.get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context();
                                 let (_, macro_arg) = main_chars
                                     .get_debug_info_and_read_ident()
                                     .expect("arg of `ifdef` must exist.");
@@ -236,7 +236,7 @@ impl<'b> Preprocessor<'b> {
                                 continue 'preprocess_loop;
                             }
                             "undef" => {
-                                main_chars.get_debug_info_and_skip_white_space_without_new_line();
+                                main_chars.get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context();
                                 let (_, macro_ident) = main_chars
                                     .get_debug_info_and_read_ident()
                                     .expect("arg(ident) of define must exist.");
@@ -245,7 +245,7 @@ impl<'b> Preprocessor<'b> {
                             }
                             "include" => {
                                 // e.g) # include "mylib.h";
-                                main_chars.get_debug_info_and_skip_white_space_without_new_line();
+                                main_chars.get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context();
                                 if let Some((_, mut str_lit)) =
                                     main_chars.get_debug_info_and_read_str_lit()
                                 {
@@ -322,16 +322,19 @@ impl<'b> Preprocessor<'b> {
     }
 
     pub fn process_define(&mut self, main_chars: &mut SrcCursor) -> Result<(), CompileError> {
-        main_chars.get_debug_info_and_skip_white_space_without_new_line();
+        main_chars
+            .get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context();
         let (_, macro_ident) = main_chars
             .get_debug_info_and_read_ident()
             .expect("arg(ident) of define must exist.");
-        main_chars.get_debug_info_and_skip_white_space_without_new_line();
+        main_chars
+            .get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context();
 
         let mut macro_value = main_chars.get_debug_info_and_read_ident();
 
         if macro_value.is_none() {
             macro_value = main_chars.get_debug_info_and_read_number();
+            eprintln!("{:?}", macro_value);
         }
 
         if macro_value.is_none() {

--- a/src/preprocess/srccursor.rs
+++ b/src/preprocess/srccursor.rs
@@ -228,6 +228,41 @@ impl SrcCursor {
         }
         Some((debug_info, TokenKind::Space(space)))
     }
+
+    pub fn get_debug_info_and_skip_white_space_without_new_line_in_preprocessor_token_context(
+        &mut self,
+    ) -> Option<(DebugInfo, TokenKind)> {
+        let debug_info = self.get_debug_info();
+        let mut space = String::new();
+        while let Some(c) = self.src.front() {
+            match *c {
+                ch @ (' ' | '\t' | 'r') => {
+                    space.push(ch);
+                    self.advance(1);
+                    continue;
+                }
+                '\\' => {
+                    space.push('\\');
+                    self.advance(1);
+                    if Some(&'\n') == self.src.front() {
+                        space.push('\n');
+                        self.advance_with_new_line(1);
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+        if space.is_empty() {
+            return None;
+        }
+        Some((debug_info, TokenKind::Space(space)))
+    }
+
     pub fn get_debug_info_and_skip_new_line(&mut self) -> Option<(DebugInfo, TokenKind)> {
         let debug_info = self.get_debug_info();
         let mut space = String::new();

--- a/test/test.c
+++ b/test/test.c
@@ -217,6 +217,11 @@ void my_assert(int index, int expected, int got) {
   }
 }
 
+void fail(char *msg) {
+  fprintf(stderr, "%s\n", msg);
+  exit(1);
+}
+
 int test0(void) { return 3; }
 
 int test0_2(void) { return g(2); }
@@ -1530,4 +1535,32 @@ int test79(void) {
 #endif
   return ret;
 }
-int test80(void) { return 0; }
+int test80(void) {
+  // clang-format off
+#define A \
+80
+  // clang-format on
+#ifndef A
+  fail("unreachable");
+#endif
+  my_assert(80, 80, A);
+#undef A
+  // clang-format off
+#define \
+A \
+2
+#ifndef \
+A
+  fail("unreachable");
+#endif
+#ifdef \
+A
+  my_assert(80, 2, A);
+#else
+  fail("unreachable");
+#endif
+#undef \
+A
+  // clang-format on
+  return 0;
+}


### PR DESCRIPTION
マクロ # 中で、\ で改行できるように実装